### PR TITLE
Fix for broken error prettifying when formatting log output

### DIFF
--- a/lib/niceql.rb
+++ b/lib/niceql.rb
@@ -15,6 +15,9 @@ module Niceql
       #red ANSI color
       "\e[0;31;49m#{err}\e[0m"
     end
+    def self.uncolorize_str(str)
+      str.gsub(/\e[\[;m\d]+/, '')
+    end
   end
 
   module ArExtentions
@@ -53,6 +56,7 @@ module Niceql
 
     def self.prettify_pg_err(err)
       return err if err[/LINE \d+/].nil?
+      err = StringColorize.uncolorize_str(err)
       err_line_num = err[/LINE \d+/][5..-1].to_i
 
       start_sql_line = err.lines[3][/(HINT|DETAIL)/] ? 4 : 3
@@ -65,7 +69,7 @@ module Niceql
       err_carret_line = err.lines[2][err.lines[1][/LINE \d+:/].length+1..-1]
       # err line painted red completly, so we just remembering it and use
       # to replace after paiting the verbs
-      err_line = err_body[err_line_num-1]
+      err_line = err_body.join[err_line_num-1].gsub(/\s*\n\s*/, ' ')
 
       # when err line is too long postgres quotes it part in doble ...
       if err_quote


### PR DESCRIPTION
The SQL may already be prettified before the error is processed here. If this is the case then the `err_line.index(err_quote)` on line 77 will return `nil`, causing a NoMethodError exception to be raised.

This change strips any color codes and removes extraneous whitespace.

This may not be the best solution, as I don't quite understand why the error is already formatted at this point. 