### PR TITLE
Remove (hidden) dependency on Rails

### DIFF
--- a/lib/niceql.rb
+++ b/lib/niceql.rb
@@ -229,7 +229,7 @@ module Niceql
 
   module ErrorExt
     def to_s
-      if Niceql.config.prettify_pg_errors && ActiveRecord::Base.configurations[Rails.env]['adapter'] == 'postgresql'
+      if Niceql.config.prettify_pg_errors && ActiveRecord::Base.connection_config['adapter'] == 'postgresql'
         Prettifier.prettify_err(super)
       else
         super
@@ -250,7 +250,7 @@ module Niceql
       self.indentation_base = 2
       self.open_bracket_is_newliner = false
       self.prettify_active_record_log_output = false
-      self.prettify_pg_errors = defined? ::ActiveRecord::Base && ActiveRecord::Base.configurations[Rails.env]['adapter'] == 'postgresql'
+      self.prettify_pg_errors = defined? ::ActiveRecord::Base && ActiveRecord::Base.connection_config['adapter'] == 'postgresql'
     end
   end
 


### PR DESCRIPTION
This avoids using Rails, which is a problem as gems sometimes only rely on ActiveRecord and don't load the whole Rails ecosystem.