### PR TITLE
Adds compatibility with Ruby<2.3. Addresses #11.

### DIFF
--- a/lib/niceql.rb
+++ b/lib/niceql.rb
@@ -82,7 +82,7 @@ module Niceql
 
       #
       start_sql_line = err.lines[3][/(HINT|DETAIL)/] ? 4 : 3
-      err_body = start_sql_line < err.lines.length ? err.lines[start_sql_line..-1] : original_sql_query&.lines
+      err_body = start_sql_line < err.lines.length ? err.lines[start_sql_line..-1] : original_sql_query.try(:lines)
 
 
       # this means original query is missing so it's nothing to prettify


### PR DESCRIPTION
Replaces the only use of the safe navigation operator `&.` with a call to `try`.
Since this is only looking one level deep, it does not make the code substantially longer or less efficient, only more backward compatible to older rubies.