### PR TITLE
Extend niceql to Arel

### DIFF
--- a/lib/niceql.rb
+++ b/lib/niceql.rb
@@ -198,6 +198,7 @@ module Niceql
         end
       end
 
+      private_class_method
       def extract_err_caret_line( err_address_line, err_line, sql_body, err )
         # LINE could be quoted ( both sides and sometimes only from one ):
         # "LINE 1: ...t_id\" = $13 AND \"products\".\"carrier_id\" = $14 AND \"product_t...\n",

--- a/lib/niceql.rb
+++ b/lib/niceql.rb
@@ -116,9 +116,9 @@ module Niceql
         sql = sql.split( SQL_COMMENTS ).each_slice(2).map{ | sql_part, comment |
           # remove additional formatting for sql_parts but leave comment intact
           [sql_part.gsub(/[\s]+/, ' '),
-           # match?(comment, /\A\s*$/) - SQL_COMMENTS gets all comment content + all whitespaced chars around
-           # so this sql_part.length == 0 || match?(comment, /\A\s*$/) checks does the comment starts from new line
-           comment && ( sql_part.length == 0 || match?(comment, /\A\s*$/) ? "\n#{comment[COMMENT_CONTENT]}\n" : comment[COMMENT_CONTENT] ) ]
+           # comment.match?(/\A\s*$/) - SQL_COMMENTS gets all comment content + all whitespaced chars around
+           # so this sql_part.length == 0 || comment.match?(/\A\s*$/) checks does the comment starts from new line
+           comment && ( sql_part.length == 0 || comment.match?(/\A\s*$/) ? "\n#{comment[COMMENT_CONTENT]}\n" : comment[COMMENT_CONTENT] ) ]
         }.flatten.join(' ')
 
         sql.gsub!(/ \n/, "\n")
@@ -185,13 +185,13 @@ module Niceql
           queries
         }.map!{ |sql|
           # we were splitting by comments and ;, so if next sql start with comment we've got a misplaced \n\n
-          match?(sql, /\A\s+\z/) ? nil : prettify_sql( sql, colorize )
+          sql.match?(/\A\s+\z/) ? nil : prettify_sql( sql, colorize )
         }.compact.join("\n\n")
       end
 
       private_class_method
       def indent_multiline( verb, indent )
-        if match?(verb, /.\s*\n\s*./)
+        if verb.match?(/.\s*\n\s*./)
           verb.lines.map!{|ln| ln.prepend(' ' * indent)}.join("\n")
         else
           verb.prepend(' ' * indent)
@@ -220,10 +220,6 @@ module Niceql
         err_caret_line.prepend("\n") unless err_line[-1] == "\n"
         err_caret_line
       end
-    end
-
-    private_class_method def self.match?(str, pattern)
-      str =~ pattern
     end
   end
 

--- a/lib/niceql/version.rb
+++ b/lib/niceql/version.rb
@@ -1,3 +1,3 @@
 module Niceql
-  VERSION = "0.3.1"
+  VERSION = '0.4.0'
 end

--- a/test/niceql/ar_test.rb
+++ b/test/niceql/ar_test.rb
@@ -1,16 +1,26 @@
 require 'active_support/testing/declarative'
 require 'test_helper'
 require 'differ'
-require 'niceql'
 require 'byebug'
 
 ActiveRecord::Base.logger = Logger.new(STDERR)
 
 ActiveRecord::Base.establish_connection(
-  adapter: "sqlite3",
-  dbfile: ":memory:",
-  database: 'niceql_test'
+  adapter: 'sqlite3',
+  database: ':memory:'
 )
+
+ActiveRecord::Migration.create_table(:users)
+ActiveRecord::Migration.create_table(:comments) do |t|
+  t.belongs_to :user
+end
+
+class User < ActiveRecord::Base
+  has_many :comments
+end
+
+class Comment < ActiveRecord::Base
+end
 
 class ARTest < Minitest::Test
   extend ::ActiveSupport::Testing::Declarative
@@ -21,10 +31,18 @@ class ARTest < Minitest::Test
 
   test 'ar_using_pg_adapter? whenever AR is < 6.1 ' do
     ActiveRecord::Base.stub(:connection_db_config, nil) {
-      ActiveRecord::Base.stub(:connection_config, {adapter: "postgresql", encoding: "utf8", database: "niceql_test"}) {
+      ActiveRecord::Base.stub(:connection_config, {adapter: 'postgresql', encoding: 'utf8', database: 'niceql_test'}) {
         assert(Niceql::NiceQLConfig.new.ar_using_pg_adapter?)
       }
     }
   end
 
+  test 'accessible through ActiveRecord and Arel' do
+    User.create
+    assert(!User.respond_to?(:to_niceql))                # ActiveRecord::Base
+    assert(User.all.to_niceql.is_a?(String))             # ActiveRecord::Relation
+    assert(User.last.comments.to_niceql.is_a?(String))   # ActiveRecord::Associations::CollectionProxy
+    assert(User.all.arel.to_niceql.is_a?(String))        # Arel::TreeManager
+    assert(User.all.arel.source.to_niceql.is_a?(String)) # Arel::Nodes::Node
+  end
 end

--- a/test/niceql/niceql_test.rb
+++ b/test/niceql/niceql_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'differ'
-require 'niceql'
 require 'byebug'
 
 ::ActiveRecord::StatementInvalid.include( Niceql::ErrorExt )

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,4 +4,4 @@ $LOAD_PATH.unshift File.expand_path('../../test/niceql', __FILE__)
 require 'minitest/autorun'
 require 'declarative'
 require 'active_record'
-
+require 'niceql'


### PR DESCRIPTION
Привет, Леш :) Как твои дела?

/in English for the general public/
In this PR I'm doing several things, and the primary one - I'm fixing the way how it is included in ActiveRecord. Currently, it has been missing Arel, which has `to_sql` methods too. Niceql would be a perfect addition there.

I have removed 2 and added 2 other classes to make the inclusion more comprehensive and consistent.

1. Removed `ActiveRecord:Base` - it doesn't have to_sql method
```
development(main)> User.niceql
NameError: undefined local variable or method `to_sql' for #<Class:0x00007f836610cea8>
Did you mean?  to_s
from /Users/nikolay/.rvm/gems/ruby-2.7.2/gems/activerecord-6.0.4.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
```
2. Removed `ActiveRecord::Associations::CollectionProxy` because it uses the same implementation as `Relation`:
```
development(main)> Attendee.last.ad_clicks.method(:to_sql).source_location
=> ["/Users/nikolay/.rvm/gems/ruby-2.7.2/gems/activerecord-6.0.4.1/lib/active_record/relation.rb", 651]
```
3. Added `Arel::TreeManager`: https://github.com/rails/rails/blob/main/activerecord/lib/arel/tree_manager.rb#L49
4. Added `Arel::Nodes::Node`: https://github.com/rails/rails/blob/main/activerecord/lib/arel/nodes/node.rb#L39

Also,  I think that `extract_err_caret_line` is meant to be a private method.