### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run tests
+      run: bundle exec rake test

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,17 @@
+name: RuboCop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run RuboCop
+      run: bundle exec rubocop --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.4
-  - 2.5
-  - 2.3
-  - 2.6

--- a/niceql.gemspec
+++ b/niceql.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("bundler", ">= 1")
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("rake", ">= 12.3.3")
-  spec.add_development_dependency("rubocop-shopify", "~> 2.0.0")
+  spec.add_development_dependency("rubocop-shopify", "~> 2.0")
 
   spec.add_development_dependency("benchmark-ips")
   spec.add_development_dependency("differ")


### PR DESCRIPTION
This PR migrates CI from Travis.org (which is no longer active) to GitHub Actions. As part of that migration it also:

1. Adds testing for more recent Ruby versions
2. Updates the version of rubocop-shopify in use
3. Makes a few syntax/style changes to get Rubocop passing
4. Removes the Travis config file

Note that the test for Ruby 2.4 is failing - because of the use of `transform_keys` which was introduced on `Hash` in Ruby 2.5. That change was introduced here - https://github.com/petergoldstein/niceql/commit/2efe6600caa33269218e264588d25644eff96968

I wasn't sure how you'd want to address that @alekseyl , so I left it as an open issue.
